### PR TITLE
[Frontend] User can see forgot password request screen

### DIFF
--- a/src/app/modules/auth/auth-routing.module.ts
+++ b/src/app/modules/auth/auth-routing.module.ts
@@ -3,14 +3,23 @@ import { Routes, RouterModule } from '@angular/router';
 import { EnsureUnauthenticatedUserGuardService } from '@service/guard/ensure-unautehnticated-user-guard.service';
 
 import { SignInComponent } from './pages/sign-in/sign-in.component';
+import { ForgotPasswordComponent } from './pages/forgot-password/forgot-password.component';
 
 const routes: Routes = [
-  { path: 'sign-in', component: SignInComponent, canActivate: [EnsureUnauthenticatedUserGuardService] },
+  {
+    path: 'sign-in',
+    component: SignInComponent,
+    canActivate: [EnsureUnauthenticatedUserGuardService],
+  },
+  {
+    path: 'forgot-password',
+    component: ForgotPasswordComponent,
+    canActivate: [EnsureUnauthenticatedUserGuardService],
+  },
 ];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
-
 export class AuthRoutingModule {}

--- a/src/app/modules/auth/auth.module.ts
+++ b/src/app/modules/auth/auth.module.ts
@@ -1,6 +1,6 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { AuthRoutingModule } from './auth-routing.module';
 
 import { AuthHeaderComponent } from './components/auth-header/auth-header.component';
@@ -19,7 +19,7 @@ import { AlertComponent } from 'app/shared/components/alert/alert.component';
     ForgotPasswordComponent,
     AlertComponent,
   ],
-  imports: [CommonModule, ReactiveFormsModule, AuthRoutingModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, AuthRoutingModule],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class AuthModule {}

--- a/src/app/modules/auth/auth.module.ts
+++ b/src/app/modules/auth/auth.module.ts
@@ -5,17 +5,21 @@ import { AuthRoutingModule } from './auth-routing.module';
 
 import { AuthHeaderComponent } from './components/auth-header/auth-header.component';
 import { FormSignInComponent } from './components/form-sign-in/form-sign-in.component';
+import { FormForgotPasswordComponent } from './components/form-forgot-password/form-forgot-password.component';
 import { SignInComponent } from './pages/sign-in/sign-in.component';
+import { ForgotPasswordComponent } from './pages/forgot-password/forgot-password.component';
 import { AlertComponent } from 'app/shared/components/alert/alert.component';
 
 @NgModule({
-  declarations: [AuthHeaderComponent, FormSignInComponent, SignInComponent, AlertComponent],
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    AuthRoutingModule
+  declarations: [
+    AuthHeaderComponent,
+    FormSignInComponent,
+    FormForgotPasswordComponent,
+    SignInComponent,
+    ForgotPasswordComponent,
+    AlertComponent,
   ],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  imports: [CommonModule, ReactiveFormsModule, AuthRoutingModule],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-
 export class AuthModule {}

--- a/src/app/modules/auth/common-style/form-layout.scss
+++ b/src/app/modules/auth/common-style/form-layout.scss
@@ -1,0 +1,32 @@
+@import "/src/stylesheets/functions/sizing";
+@import "~bootstrap/scss/bootstrap-grid.scss";
+
+:host {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  background-image: url("/assets/images/background.png");
+  background-position: center;
+  background-size: cover;
+}
+
+.common-layout {
+  display: flex;
+  width: rem(320px);
+  flex-direction: column;
+  justify-content: center;
+
+  padding: rem(10px);
+
+  @include media-breakpoint-up(md) {
+    padding: 0;
+    width: rem(400px);
+  }
+
+  @include media-breakpoint-up(lg) {
+    width: rem(500px);
+  }
+}

--- a/src/app/modules/auth/components/auth-header/auth-header.component.html
+++ b/src/app/modules/auth/components/auth-header/auth-header.component.html
@@ -1,4 +1,4 @@
 <div class="auth-header">
-  <img src="assets/images/logo.svg" class="auth-header__logo"/>
+  <img src="assets/images/logo.svg" class="auth-header__logo" />
   <p class="auth-header__subtitle">Sign in to Nimble</p>
 </div>

--- a/src/app/modules/auth/components/auth-header/auth-header.component.html
+++ b/src/app/modules/auth/components/auth-header/auth-header.component.html
@@ -1,4 +1,4 @@
 <div class="auth-header">
   <img src="assets/images/logo.svg" class="auth-header__logo" />
-  <p class="auth-header__subtitle">Sign in to Nimble</p>
+  <p class="auth-header__subtitle">{{ subTitle }}</p>
 </div>

--- a/src/app/modules/auth/components/auth-header/auth-header.component.spec.ts
+++ b/src/app/modules/auth/components/auth-header/auth-header.component.spec.ts
@@ -8,19 +8,19 @@ describe('AuthHeaderComponent', () => {
 
   const SELECTORS = {
     headerLogo: '.auth-header__logo',
-    headerTitle: '.auth-header__subtitle'
+    headerTitle: '.auth-header__subtitle',
   };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AuthHeaderComponent]
-    })
-      .compileComponents();
+      declarations: [AuthHeaderComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AuthHeaderComponent);
     component = fixture.componentInstance;
+    component.subTitle = 'Sign in to Nimble';
     baseElement = fixture.nativeElement;
     fixture.detectChanges();
   });
@@ -30,7 +30,11 @@ describe('AuthHeaderComponent', () => {
   });
 
   it('renders header', () => {
-    expect(baseElement.querySelector(SELECTORS.headerLogo).src).toContain('assets/images/logo.svg');
-    expect(baseElement.querySelector(SELECTORS.headerTitle).textContent).toContain('Sign in to Nimble');
+    expect(baseElement.querySelector(SELECTORS.headerLogo).src).toContain(
+      'assets/images/logo.svg'
+    );
+    expect(
+      baseElement.querySelector(SELECTORS.headerTitle).textContent
+    ).toContain('Sign in to Nimble');
   });
 });

--- a/src/app/modules/auth/components/auth-header/auth-header.component.ts
+++ b/src/app/modules/auth/components/auth-header/auth-header.component.ts
@@ -1,12 +1,13 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-auth-header',
   templateUrl: './auth-header.component.html',
-  styleUrls: ['./auth-header.component.scss']
+  styleUrls: ['./auth-header.component.scss'],
 })
-
 export class AuthHeaderComponent implements OnInit {
+  @Input() subTitle: string = '';
+
   constructor() {}
 
   ngOnInit(): void {}

--- a/src/app/modules/auth/components/auth-header/auth-header.component.ts
+++ b/src/app/modules/auth/components/auth-header/auth-header.component.ts
@@ -6,7 +6,7 @@ import { Component, Input, OnInit } from '@angular/core';
   styleUrls: ['./auth-header.component.scss'],
 })
 export class AuthHeaderComponent implements OnInit {
-  @Input() subTitle: string = '';
+  @Input() subTitle = '';
 
   constructor() {}
 

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
@@ -6,10 +6,11 @@
   ></app-alert>
 </div>
 
-<form class="form-forgot-password">
+<form [formGroup]="forgotPasswordForm" class="form-forgot-password">
   <div class="form-group">
     <label for="email" class="form-forgot-password__label">Email</label>
     <input
+      formControlName="email"
       name="email"
       id="email"
       type="email"
@@ -18,7 +19,11 @@
     />
   </div>
 
-  <button class="btn btn-primary btn-block" type="submit">
+  <button
+    [disabled]="!forgotPasswordForm.valid"
+    class="btn btn-primary btn-block"
+    type="submit"
+  >
     Send Recovery Email
   </button>
 </form>

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
@@ -1,5 +1,5 @@
-<div *ngIf="errorMessage !== ''">
-  <app-alert [errorMessage]="errorMessage"></app-alert>
+<div *ngIf="alertMessage !== ''">
+  <app-alert [alertMessage]="alertMessage"></app-alert>
 </div>
 
 <form class="form-forgot-password">

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
@@ -1,0 +1,20 @@
+<div *ngIf="errorMessage !== ''">
+  <app-alert [errorMessage]="errorMessage"></app-alert>
+</div>
+
+<form class="form-forgot-password">
+  <div class="form-group">
+    <label for="email" class="form-forgot-password__label">Email</label>
+    <input
+      name="email"
+      id="email"
+      type="email"
+      class="form-control form-forgot-password__input"
+      required
+    />
+  </div>
+
+  <button class="btn btn-primary btn-block" type="submit">
+    Send Recovery Email
+  </button>
+</form>

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
@@ -1,5 +1,9 @@
 <div *ngIf="alertMessage !== ''">
-  <app-alert [alertMessage]="alertMessage"></app-alert>
+  <app-alert
+    [iconSource]="alertIconSource"
+    [title]="alertTitle"
+    [message]="alertMessage"
+  ></app-alert>
 </div>
 
 <form class="form-forgot-password">

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="alertMessage !== ''">
   <app-alert
-    [iconSource]="alertIconSource"
+    [icon]="alertIcon"
     [title]="alertTitle"
     [message]="alertMessage"
   ></app-alert>

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.scss
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.scss
@@ -10,4 +10,16 @@
 
     cursor: pointer;
   }
+
+  &__input:last-of-type {
+    display: inline;
+    padding-right: rem(95px);
+  }
+
+  &__forgot-password {
+    color: map-get($brand-gray, 600);
+    margin-left: rem(-90px);
+    font-size: map-get($font-sizes, "sm");
+    line-height: rem(20px);
+  }
 }

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.scss
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.scss
@@ -10,16 +10,4 @@
 
     cursor: pointer;
   }
-
-  &__input:last-of-type {
-    display: inline;
-    padding-right: rem(95px);
-  }
-
-  &__forgot-password {
-    color: map-get($brand-gray, 600);
-    margin-left: rem(-90px);
-    font-size: map-get($font-sizes, "sm");
-    line-height: rem(20px);
-  }
 }

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.scss
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.scss
@@ -1,0 +1,13 @@
+@import "variables";
+@import "functions/sizing";
+
+.form-forgot-password {
+  margin-top: rem(32px);
+
+  &__label {
+    font-weight: $font-weight-bold;
+    font-size: map-get($font-sizes, "sm");
+
+    cursor: pointer;
+  }
+}

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.spec.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { FormForgotPasswordComponent } from './form-forgot-password.component';
 
 describe('FormForgotPasswordComponent', () => {
@@ -8,9 +7,8 @@ describe('FormForgotPasswordComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ FormForgotPasswordComponent ]
-    })
-    .compileComponents();
+      declarations: [FormForgotPasswordComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -19,7 +17,7 @@ describe('FormForgotPasswordComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('renders the component', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.spec.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormForgotPasswordComponent } from './form-forgot-password.component';
+
+describe('FormForgotPasswordComponent', () => {
+  let component: FormForgotPasswordComponent;
+  let fixture: ComponentFixture<FormForgotPasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FormForgotPasswordComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormForgotPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.spec.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.spec.ts
@@ -4,6 +4,12 @@ import { FormForgotPasswordComponent } from './form-forgot-password.component';
 describe('FormForgotPasswordComponent', () => {
   let component: FormForgotPasswordComponent;
   let fixture: ComponentFixture<FormForgotPasswordComponent>;
+  let baseElement: any;
+
+  const SELECTORS = {
+    emailField: '.form-forgot-password input[type="email"]',
+    submitButton: '.form-forgot-password button[type="submit"]',
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,10 +20,16 @@ describe('FormForgotPasswordComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(FormForgotPasswordComponent);
     component = fixture.componentInstance;
+    baseElement = fixture.nativeElement;
     fixture.detectChanges();
   });
 
   it('renders the component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('renders forgot form', () => {
+    expect(baseElement.querySelector(SELECTORS.emailField)).toBeTruthy();
+    expect(baseElement.querySelector(SELECTORS.submitButton)).toBeTruthy();
   });
 });

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
@@ -6,7 +6,10 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./form-forgot-password.component.scss'],
 })
 export class FormForgotPasswordComponent implements OnInit {
-  errorMessage = 'We’ve email you instructions to reset your password.';
+  alertTitle = 'Check your email.';
+  alertMessage = 'We’ve email you instructions to reset your password.';
+  alertIcon = 'bell';
+
   constructor() {}
 
   ngOnInit(): void {}

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
@@ -6,6 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./form-forgot-password.component.scss'],
 })
 export class FormForgotPasswordComponent implements OnInit {
+  errorMessage = 'We’ve email you instructions to reset your password.';
   constructor() {}
 
   ngOnInit(): void {}

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-form-forgot-password',
+  templateUrl: './form-forgot-password.component.html',
+  styleUrls: ['./form-forgot-password.component.scss'],
+})
+export class FormForgotPasswordComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
@@ -6,7 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./form-forgot-password.component.scss'],
 })
 export class FormForgotPasswordComponent implements OnInit {
-  alertIconSource = 'assets/images/icon-sprite.svg#notification';
+  alertIcon = 'notification';
   alertTitle = 'Check your email.';
   alertMessage = 'We’ve email you instructions to reset your password.';
 

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
@@ -6,9 +6,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./form-forgot-password.component.scss'],
 })
 export class FormForgotPasswordComponent implements OnInit {
-  alertIcon = 'notification';
-  alertTitle = 'Check your email.';
-  alertMessage = 'We’ve email you instructions to reset your password.';
+  alertIcon = '';
+  alertTitle = '';
+  alertMessage = '';
 
   constructor() {}
 

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
@@ -6,9 +6,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./form-forgot-password.component.scss'],
 })
 export class FormForgotPasswordComponent implements OnInit {
+  alertIconSource = 'assets/images/icon-sprite.svg#notification';
   alertTitle = 'Check your email.';
   alertMessage = 'We’ve email you instructions to reset your password.';
-  alertIcon = 'bell';
 
   constructor() {}
 

--- a/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
+++ b/src/app/modules/auth/components/form-forgot-password/form-forgot-password.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 @Component({
   selector: 'app-form-forgot-password',
@@ -6,11 +7,16 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./form-forgot-password.component.scss'],
 })
 export class FormForgotPasswordComponent implements OnInit {
+  forgotPasswordForm: any;
   alertIcon = '';
   alertTitle = '';
   alertMessage = '';
 
   constructor() {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.forgotPasswordForm = new FormGroup({
+      email: new FormControl('', [Validators.required, Validators.email]),
+    });
+  }
 }

--- a/src/app/modules/auth/components/form-sign-in/form-sign-in.component.html
+++ b/src/app/modules/auth/components/form-sign-in/form-sign-in.component.html
@@ -18,7 +18,7 @@
       name="email"
       id="email"
       type="email"
-      class="form-control"
+      class="form-control form-sign-in__input"
       required
     />
   </div>
@@ -29,9 +29,12 @@
       name="password"
       type="password"
       id="password"
-      class="form-control"
+      class="form-control form-sign-in__input"
       required
     />
+    <a routerLink="/auth/forgot-password" class="form-sign-in__forgot-password"
+      >Forgot?</a
+    >
   </div>
   <button
     [disabled]="!signInForm.valid"

--- a/src/app/modules/auth/components/form-sign-in/form-sign-in.component.html
+++ b/src/app/modules/auth/components/form-sign-in/form-sign-in.component.html
@@ -1,17 +1,43 @@
-<div *ngIf="errorMessage !== ''">
-  <app-alert [errorMessage]="errorMessage"></app-alert>
+<div *ngIf="alertMessage !== ''">
+  <app-alert
+    [iconSource]="alertIconSource"
+    [title]="alertTitle"
+    [message]="alertMessage"
+  ></app-alert>
 </div>
 
-<form [formGroup]="signInForm" (ngSubmit)="onSubmit(signInForm.value)" class="form-sign-in">
+<form
+  [formGroup]="signInForm"
+  (ngSubmit)="onSubmit(signInForm.value)"
+  class="form-sign-in"
+>
   <div class="form-group">
     <label for="email" class="form-sign-in__label">Email</label>
-    <input formControlName="email" name="email" id="email" type="email" class="form-control" required
+    <input
+      formControlName="email"
+      name="email"
+      id="email"
+      type="email"
+      class="form-control"
+      required
     />
   </div>
   <div class="form-group">
     <label for="password" class="form-sign-in__label">Password</label>
-    <input formControlName="password" name="password" type="password" id="password" class="form-control" required
+    <input
+      formControlName="password"
+      name="password"
+      type="password"
+      id="password"
+      class="form-control"
+      required
     />
   </div>
-  <button [disabled]="!signInForm.valid" class="btn btn-primary btn-block" type="submit">Sign in</button>
+  <button
+    [disabled]="!signInForm.valid"
+    class="btn btn-primary btn-block"
+    type="submit"
+  >
+    Sign in
+  </button>
 </form>

--- a/src/app/modules/auth/components/form-sign-in/form-sign-in.component.html
+++ b/src/app/modules/auth/components/form-sign-in/form-sign-in.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="alertMessage !== ''">
   <app-alert
-    [iconSource]="alertIconSource"
+    [icon]="alertIcon"
     [title]="alertTitle"
     [message]="alertMessage"
   ></app-alert>

--- a/src/app/modules/auth/components/form-sign-in/form-sign-in.component.scss
+++ b/src/app/modules/auth/components/form-sign-in/form-sign-in.component.scss
@@ -10,4 +10,16 @@
 
     cursor: pointer;
   }
+
+  &__input:last-of-type {
+    display: inline;
+    padding-right: rem(95px);
+  }
+
+  &__forgot-password {
+    color: map-get($brand-gray, 600);
+    margin-left: rem(-90px);
+    font-size: map-get($font-sizes, 'sm');
+    line-height: rem(20px);
+  }
 }

--- a/src/app/modules/auth/components/form-sign-in/form-sign-in.component.spec.ts
+++ b/src/app/modules/auth/components/form-sign-in/form-sign-in.component.spec.ts
@@ -23,12 +23,8 @@ describe('FormSignInComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [FormSignInComponent],
-      imports: [
-        HttpClientModule,
-        RouterTestingModule.withRoutes([])
-      ]
-    })
-      .compileComponents();
+      imports: [HttpClientModule, RouterTestingModule.withRoutes([])],
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -60,7 +56,7 @@ describe('FormSignInComponent', () => {
           tokenType: 'Bearer',
           expiresIn: 7200,
           refreshToken: 'refresh_token',
-          createdAt: 1606198702
+          createdAt: 1606198702,
         };
 
         spyOn(authenticationService, 'signIn').and.returnValue(of([response]));
@@ -72,13 +68,16 @@ describe('FormSignInComponent', () => {
     });
 
     describe('Given invalid credentials', () => {
-      it('sets error message to errorMessage variable', () => {
+      it('sets error message to alertMessage variable', () => {
         const data = { email: 'john@example.com', password: 'invalid-pass' };
-        const expectedErrorMessage = 'Email or Password is invalid. Please try again.';
-        spyOn(authenticationService, 'signIn').and.returnValue(throwError(expectedErrorMessage));
+        const expectedAlertMessage =
+          'Email or Password is invalid. Please try again.';
+        spyOn(authenticationService, 'signIn').and.returnValue(
+          throwError(expectedAlertMessage)
+        );
 
         component.onSubmit(data);
-        expect(component.errorMessage).toBe(expectedErrorMessage);
+        expect(component.alertMessage).toBe(expectedAlertMessage);
       });
     });
   });

--- a/src/app/modules/auth/components/form-sign-in/form-sign-in.component.ts
+++ b/src/app/modules/auth/components/form-sign-in/form-sign-in.component.ts
@@ -11,6 +11,8 @@ import { Router } from '@angular/router';
 })
 export class FormSignInComponent implements OnInit {
   signInForm: any;
+  alertIconSource = 'assets/images/icon-sprite.svg#error';
+  alertTitle = 'Error';
   alertMessage = '';
 
   constructor(

--- a/src/app/modules/auth/components/form-sign-in/form-sign-in.component.ts
+++ b/src/app/modules/auth/components/form-sign-in/form-sign-in.component.ts
@@ -7,35 +7,37 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'app-form-sign-in',
   templateUrl: './form-sign-in.component.html',
-  styleUrls: ['./form-sign-in.component.scss']
+  styleUrls: ['./form-sign-in.component.scss'],
 })
-
 export class FormSignInComponent implements OnInit {
   signInForm: any;
-  errorMessage = '';
+  alertMessage = '';
 
   constructor(
     private _authService: AuthenticationService,
     private _sessionService: SessionService,
-    private _router: Router){
-  }
+    private _router: Router
+  ) {}
 
-  ngOnInit(): void{
+  ngOnInit(): void {
     this.signInForm = new FormGroup({
       email: new FormControl('', [Validators.required, Validators.email]),
       password: new FormControl('', [Validators.required]),
     });
   }
 
-  onSubmit(data: any): void{
-    this.errorMessage = '';
+  onSubmit(data: any): void {
+    this.alertMessage = '';
 
-    this._authService.signIn(data).subscribe(response => {
-      this._sessionService.setAccessToken(response.accessToken);
+    this._authService.signIn(data).subscribe(
+      (response) => {
+        this._sessionService.setAccessToken(response.accessToken);
 
-      this._router.navigate(['/']);
-    }, error => {
-      this.errorMessage = error;
-    });
+        this._router.navigate(['/']);
+      },
+      (error) => {
+        this.alertMessage = error;
+      }
+    );
   }
 }

--- a/src/app/modules/auth/components/form-sign-in/form-sign-in.component.ts
+++ b/src/app/modules/auth/components/form-sign-in/form-sign-in.component.ts
@@ -11,7 +11,7 @@ import { Router } from '@angular/router';
 })
 export class FormSignInComponent implements OnInit {
   signInForm: any;
-  alertIconSource = 'assets/images/icon-sprite.svg#error';
+  alertIcon = 'error';
   alertTitle = 'Error';
   alertMessage = '';
 

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.html
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.html
@@ -1,4 +1,6 @@
-<app-auth-header [subTitle]="headerSubTitle"></app-auth-header>
+<div class="forgot-password-header">
+  <app-auth-header [subTitle]="headerSubTitle"></app-auth-header>
+</div>
 
 <main class="forgot-password-content">
   <app-form-forgot-password></app-form-forgot-password>

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.html
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.html
@@ -1,0 +1,5 @@
+<app-auth-header></app-auth-header>
+
+<main class="forgot-password-content">
+  <app-form-forgot-password></app-form-forgot-password>
+</main>

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.html
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.html
@@ -1,4 +1,4 @@
-<app-auth-header></app-auth-header>
+<app-auth-header [subTitle]="headerSubTitle"></app-auth-header>
 
 <main class="forgot-password-content">
   <app-form-forgot-password></app-form-forgot-password>

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.scss
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.scss
@@ -1,0 +1,33 @@
+@import "/src/stylesheets/functions/sizing";
+@import "/src/stylesheets/variables";
+@import "~bootstrap/scss/bootstrap-grid.scss";
+
+:host {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  background-image: url("/assets/images/background.png");
+  background-position: center;
+  background-size: cover;
+}
+
+.forgot-password-content {
+  display: flex;
+  width: rem(320px);
+  flex-direction: column;
+  justify-content: center;
+
+  padding: rem(10px);
+
+  @include media-breakpoint-up(md) {
+    padding: 0;
+    width: rem(400px);
+  }
+
+  @include media-breakpoint-up(lg) {
+    width: rem(500px);
+  }
+}

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.scss
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.scss
@@ -1,34 +1,9 @@
 @import "/src/stylesheets/functions/sizing";
 @import "/src/stylesheets/variables";
 @import "~bootstrap/scss/bootstrap-grid.scss";
-
-:host {
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  background-image: url("/assets/images/background.png");
-  background-position: center;
-  background-size: cover;
-}
+@import "../../common-style/form-layout.scss";
 
 .forgot-password-content,
 .forgot-password-header {
-  display: flex;
-  width: rem(320px);
-  flex-direction: column;
-  justify-content: center;
-
-  padding: rem(10px);
-
-  @include media-breakpoint-up(md) {
-    padding: 0;
-    width: rem(400px);
-  }
-
-  @include media-breakpoint-up(lg) {
-    width: rem(500px);
-  }
+  @extend .common-layout;
 }

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.scss
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.scss
@@ -14,7 +14,8 @@
   background-size: cover;
 }
 
-.forgot-password-content {
+.forgot-password-content,
+.forgot-password-header {
   display: flex;
   width: rem(320px);
   flex-direction: column;

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ForgotPasswordComponent } from './forgot-password.component';
+
+describe('ForgotPasswordComponent', () => {
+  let component: ForgotPasswordComponent;
+  let fixture: ComponentFixture<ForgotPasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ForgotPasswordComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ForgotPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.spec.ts
@@ -8,9 +8,8 @@ describe('ForgotPasswordComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ForgotPasswordComponent ]
-    })
-    .compileComponents();
+      declarations: [ForgotPasswordComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -19,7 +18,7 @@ describe('ForgotPasswordComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('renders the component', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.ts
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-forgot-password',
+  templateUrl: './forgot-password.component.html',
+  styleUrls: ['./forgot-password.component.scss'],
+})
+export class ForgotPasswordComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/modules/auth/pages/forgot-password/forgot-password.component.ts
+++ b/src/app/modules/auth/pages/forgot-password/forgot-password.component.ts
@@ -6,6 +6,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./forgot-password.component.scss'],
 })
 export class ForgotPasswordComponent implements OnInit {
+  headerSubTitle =
+    'Enter your email to receive instructions for resetting your password.';
+
   constructor() {}
 
   ngOnInit(): void {}

--- a/src/app/modules/auth/pages/sign-in/sign-in.component.html
+++ b/src/app/modules/auth/pages/sign-in/sign-in.component.html
@@ -1,4 +1,4 @@
-<app-auth-header></app-auth-header>
+<app-auth-header [subTitle]="headerSubTitle"></app-auth-header>
 
 <main class="sign-in-content">
   <app-form-sign-in></app-form-sign-in>

--- a/src/app/modules/auth/pages/sign-in/sign-in.component.html
+++ b/src/app/modules/auth/pages/sign-in/sign-in.component.html
@@ -1,4 +1,6 @@
-<app-auth-header [subTitle]="headerSubTitle"></app-auth-header>
+<div class="sign-in-header">
+  <app-auth-header [subTitle]="headerSubTitle"></app-auth-header>
+</div>
 
 <main class="sign-in-content">
   <app-form-sign-in></app-form-sign-in>

--- a/src/app/modules/auth/pages/sign-in/sign-in.component.scss
+++ b/src/app/modules/auth/pages/sign-in/sign-in.component.scss
@@ -1,33 +1,9 @@
-@import '/src/stylesheets/functions/sizing';
-@import '/src/stylesheets/variables';
+@import "/src/stylesheets/functions/sizing";
+@import "/src/stylesheets/variables";
 @import "~bootstrap/scss/bootstrap-grid.scss";
+@import "../../common-style/form-layout.scss";
 
-:host {
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  background-image: url('/assets/images/background.png');
-  background-position: center;
-  background-size: cover;
-}
-
-.sign-in-content {
-  display: flex;
-  width: rem(320px);
-  flex-direction: column;
-  justify-content: center;
-
-  padding: rem(10px);
-
-  @include media-breakpoint-up(md) {
-    padding: 0;
-    width: rem(400px);
-  }
-
-  @include media-breakpoint-up(lg) {
-    width: rem(500px);
-  }
+.sign-in-content,
+.sign-in-header {
+  @extend .common-layout;
 }

--- a/src/app/modules/auth/pages/sign-in/sign-in.component.ts
+++ b/src/app/modules/auth/pages/sign-in/sign-in.component.ts
@@ -3,10 +3,10 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'app-sign-in',
   templateUrl: './sign-in.component.html',
-  styleUrls: ['./sign-in.component.scss']
+  styleUrls: ['./sign-in.component.scss'],
 })
-
 export class SignInComponent implements OnInit {
+  headerSubTitle = 'Sign in to Nimble';
   constructor() {}
 
   ngOnInit(): void {}

--- a/src/app/shared/components/alert/alert.component.html
+++ b/src/app/shared/components/alert/alert.component.html
@@ -4,11 +4,9 @@
   </div>
 
   <div class="alert__content">
-    <div class="alert__title">
-      Error
-    </div>
+    <div class="alert__title">Error</div>
     <div class="alert__message">
-      {{ errorMessage }}
+      {{ alertMessage }}
     </div>
   </div>
 </div>

--- a/src/app/shared/components/alert/alert.component.html
+++ b/src/app/shared/components/alert/alert.component.html
@@ -1,12 +1,12 @@
 <div class="alert alert--dark">
   <div class="alert__icon">
-    <svg-icon src="assets/images/icon-sprite.svg#error" class="icon"></svg-icon>
+    <svg-icon src="{{ iconSource }}" class="icon"></svg-icon>
   </div>
 
   <div class="alert__content">
-    <div class="alert__title">Error</div>
+    <div class="alert__title">{{ title }}</div>
     <div class="alert__message">
-      {{ alertMessage }}
+      {{ message }}
     </div>
   </div>
 </div>

--- a/src/app/shared/components/alert/alert.component.html
+++ b/src/app/shared/components/alert/alert.component.html
@@ -1,8 +1,18 @@
 <div class="alert alert--dark">
   <div class="alert__icon">
-    <svg-icon src="{{ iconSource }}" class="icon"></svg-icon>
+    <ng-template [ngIf]="icon == 'error'">
+      <svg-icon
+        src="assets/images/icon-sprite.svg#error"
+        class="icon"
+      ></svg-icon>
+    </ng-template>
+    <ng-template [ngIf]="icon == 'notification'">
+      <svg-icon
+        src="assets/images/icon-sprite.svg#notification"
+        class="icon"
+      ></svg-icon>
+    </ng-template>
   </div>
-
   <div class="alert__content">
     <div class="alert__title">{{ title }}</div>
     <div class="alert__message">

--- a/src/app/shared/components/alert/alert.component.ts
+++ b/src/app/shared/components/alert/alert.component.ts
@@ -6,7 +6,9 @@ import { Component, Input, OnInit } from '@angular/core';
   styleUrls: ['./alert.component.scss'],
 })
 export class AlertComponent implements OnInit {
-  @Input() alertMessage = '';
+  @Input() message = '';
+  @Input() iconSource = '';
+  @Input() title = '';
 
   constructor() {}
 

--- a/src/app/shared/components/alert/alert.component.ts
+++ b/src/app/shared/components/alert/alert.component.ts
@@ -3,15 +3,12 @@ import { Component, Input, OnInit } from '@angular/core';
 @Component({
   selector: 'app-alert',
   templateUrl: './alert.component.html',
-  styleUrls: ['./alert.component.scss']
+  styleUrls: ['./alert.component.scss'],
 })
-
 export class AlertComponent implements OnInit {
-  @Input() errorMessage = '';
+  @Input() alertMessage = '';
 
-  constructor(){
-  }
+  constructor() {}
 
-  ngOnInit(): void{
-  }
+  ngOnInit(): void {}
 }

--- a/src/app/shared/components/alert/alert.component.ts
+++ b/src/app/shared/components/alert/alert.component.ts
@@ -7,7 +7,7 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class AlertComponent implements OnInit {
   @Input() message = '';
-  @Input() iconSource = '';
+  @Input() icon = '';
   @Input() title = '';
 
   constructor() {}


### PR DESCRIPTION
https://github.com/junan/nimble-survey/projects/1#card-49203144

## What happened

User can see forgot password request screen from `/auth/forgot-password` route or by clicking the `Forgot?` link in the sign in page.

## Insight

- Introduced `/auth/forgot-password` route for forget password page
- Adjusted Alert and Auth header component so we can pass dynamic value into them.
- Separated common form style in `common-style/form-layout.scss `
- Used [prettier](https://prettier.io/) with vs code to format code

## Proof of Work

![Screen Shot 2020-12-24 at 2 45 31 PM](https://user-images.githubusercontent.com/6076762/103072031-6b0a2e00-45f7-11eb-8118-d5e680d85f42.png)
![Screen Shot 2020-12-24 at 2 50 36 PM](https://user-images.githubusercontent.com/6076762/103072040-6e9db500-45f7-11eb-8304-b0dc690ef416.png)

